### PR TITLE
fix: composer and Magento module dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
   ],
   "require": {
     "magento/framework": "^103.0",
-    "magento/module-config": "^101.0",
-    "magento/module-store": "^101.0",
-    "magento/module-theme": "^101.0"
+    "magento/module-backend": "^102.0",
+    "magento/module-config": "^101.0"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
   ],
   "require": {
     "magento/framework": "^103.0",
-    "mage-os/theme-adminhtml-m137": "^1.0"
+    "magento/module-config": "^101.0",
+    "magento/module-store": "^101.0",
+    "magento/module-theme": "^101.0"
   },
   "autoload": {
     "files": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,6 +4,9 @@
     <module name="MageOS_ThemeAdminhtmlSwitcher">
         <sequence>
             <module name="Magento_Backend"/>
+            <module name="Magento_Theme"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_Config"/>
         </sequence>
     </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,9 +4,9 @@
     <module name="MageOS_ThemeAdminhtmlSwitcher">
         <sequence>
             <module name="Magento_Backend"/>
-            <module name="Magento_Theme"/>
-            <module name="Magento_Store"/>
             <module name="Magento_Config"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_Theme"/>
         </sequence>
     </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,8 +5,6 @@
         <sequence>
             <module name="Magento_Backend"/>
             <module name="Magento_Config"/>
-            <module name="Magento_Store"/>
-            <module name="Magento_Theme"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
This adds Magento module `<sequence>` and composer `require` dependencies for Magento core modules referenced in the code.

I removed the require for
```
    "mage-os/theme-adminhtml-m137": "^1.0"
```
to avoid a circular dependency, which can cause issues. The theme requires this switcher module.