### PR TITLE
Early return for non-admin areas

### DIFF
--- a/Plugin/ThemeAdminhtmlSwitcherPlugin.php
+++ b/Plugin/ThemeAdminhtmlSwitcherPlugin.php
@@ -5,6 +5,7 @@ namespace MageOS\ThemeAdminhtmlSwitcher\Plugin;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Theme\Model\View\Design;
+use Magento\Framework\App\Area;
 
 class ThemeAdminhtmlSwitcherPlugin
 {
@@ -30,6 +31,10 @@ class ThemeAdminhtmlSwitcherPlugin
      */
     public function beforeSetDesignTheme(Design $subject, $themeId = null)
     {
+        if ($subject->getArea() !== Area::AREA_ADMINHTML) {
+            return [$themeId];
+        }
+        
         $isEnabled = $this->scopeConfig->isSetFlag(
             'admin/system_admin_design/enable_theme_adminhtml_m137',
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT


### PR DESCRIPTION
Plugin is under etc/adminhtml, so it shouldn't get executed in admin area anyway. However in case of area emulation, it might still get called - for such cases this early return should avoid trouble.