### PR TITLE
Early return for non-admin areas when emulation is called but not started yet

### DIFF
--- a/Plugin/ThemeAdminhtmlSwitcherPlugin.php
+++ b/Plugin/ThemeAdminhtmlSwitcherPlugin.php
@@ -27,14 +27,19 @@ class ThemeAdminhtmlSwitcherPlugin
      *
      * @param Design $subject
      * @param string|null $themeId
+     * @param string|null $area
      * @return array
      */
-    public function beforeSetDesignTheme(Design $subject, $themeId = null)
+    public function beforeSetDesignTheme(Design $subject, $themeId = null, $area = null)
     {
-        if ($subject->getArea() !== Area::AREA_ADMINHTML) {
-            return [$themeId];
+        if ($area !== null && $area !== Area::AREA_ADMINHTML) {
+            return [$themeId, $area];
         }
-        
+
+        if ($subject->getArea() !== Area::AREA_ADMINHTML) {
+            return [$themeId, $area];
+        }
+
         $isEnabled = $this->scopeConfig->isSetFlag(
             'admin/system_admin_design/enable_theme_adminhtml_m137',
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT
@@ -44,6 +49,6 @@ class ThemeAdminhtmlSwitcherPlugin
             $themeId = 'MageOS/m137-admin-theme';
         }
 
-        return [$themeId];
+        return [$themeId, $area];
     }
 }


### PR DESCRIPTION
Turns out that setDesignTheme is also called within startEmulation function, so when you start emulation, intended area code might not be set yet, but will be available as an optional parameter.
So first we have to check if that parameter is passed and if it's something else than admin.

The early return I made in previous pr is still needed, because this function also gets executed when emulation is already in place.