### PR TITLE
Add the ability to manually select the active admin theme

### DIFF
--- a/Model/Config/Source/AdminThemeList.php
+++ b/Model/Config/Source/AdminThemeList.php
@@ -34,7 +34,10 @@ class AdminThemeList implements OptionSourceInterface
             $path = $theme->getData('theme_path');
 
             // Replace default admin theme title as 'Magento 2 backend' is not user friendly
-            $title = ($path === 'Magento/backend') ? (string) __('Magento Default') : $theme->getData('theme_title');
+            $title = $theme->getData('theme_title');
+            if ($path === 'Magento/backend') {
+                $title = (string)__('Magento Default');
+            }
 
             $themes[$title] = [
                 'label' => $title . ' (' . $path . ')',

--- a/Model/Config/Source/AdminThemeList.php
+++ b/Model/Config/Source/AdminThemeList.php
@@ -10,11 +10,21 @@ class AdminThemeList implements OptionSourceInterface
 {
     private ThemeList $themeList;
 
+    /**
+     * AdminThemeList constructor.
+     *
+     * @param ThemeList $themeList
+     */
     public function __construct(ThemeList $themeList)
     {
         $this->themeList = $themeList;
     }
 
+    /**
+     * Get a list of all installed adminhtml themes.
+     *
+     * @return array
+     */
     public function toOptionArray(): array
     {
         $themes = [];

--- a/Model/Config/Source/AdminThemeList.php
+++ b/Model/Config/Source/AdminThemeList.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace MageOS\ThemeAdminhtmlSwitcher\Model\Config\Source;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Framework\View\Design\Theme\ThemeList;
+
+class AdminThemeList implements OptionSourceInterface
+{
+    private ThemeList $themeList;
+
+    public function __construct(ThemeList $themeList)
+    {
+        $this->themeList = $themeList;
+    }
+
+    public function toOptionArray(): array
+    {
+        $themes = [];
+        $this->themeList->addConstraint(ThemeList::CONSTRAINT_AREA, Area::AREA_ADMINHTML);
+
+        foreach ($this->themeList->getItems() as $theme) {
+            $path = $theme->getData('theme_path');
+
+            // Replace default admin theme title as 'Magento 2 backend' is not user friendly
+            $title = ($path === 'Magento/backend') ? (string) __('Magento Default') : $theme->getData('theme_title');
+
+            $themes[$title] = [
+                'label' => $title . ' (' . $path . ')',
+                'value' => $path
+            ];
+        }
+
+        ksort($themes); // Sort themes alphabetically
+
+        return $themes;
+    }
+}

--- a/Plugin/ThemeAdminhtmlSwitcherPlugin.php
+++ b/Plugin/ThemeAdminhtmlSwitcherPlugin.php
@@ -3,13 +3,12 @@
 namespace MageOS\ThemeAdminhtmlSwitcher\Plugin;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Store\Model\ScopeInterface;
 use Magento\Theme\Model\View\Design;
 use Magento\Framework\App\Area;
 
 class ThemeAdminhtmlSwitcherPlugin
 {
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     /**
      * ThemeAdminhtmlSwitcherPlugin constructor.

--- a/Plugin/ThemeAdminhtmlSwitcherPlugin.php
+++ b/Plugin/ThemeAdminhtmlSwitcherPlugin.php
@@ -40,15 +40,11 @@ class ThemeAdminhtmlSwitcherPlugin
             return [$themeId, $area];
         }
 
-        $isEnabled = $this->scopeConfig->isSetFlag(
-            'admin/system_admin_design/enable_theme_adminhtml_m137',
+        $activeTheme = $this->scopeConfig->getValue(
+            'admin/system_admin_design/active_theme',
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT
         );
-
-        if ($isEnabled) {
-            $themeId = 'MageOS/m137-admin-theme';
-        }
-
-        return [$themeId, $area];
+        
+        return [$activeTheme ?? $themeId, $area];
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/system_file.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="admin">
             <group id="system_admin_design" translate="label" type="text" sortOrder="2100" showInDefault="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,9 +5,9 @@
         <section id="admin">
             <group id="system_admin_design" translate="label" type="text" sortOrder="2100" showInDefault="1">
                 <label>Admin Design</label>
-                <field id="enable_theme_adminhtml_m137" translate="label" type="select" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Enable M137 Admin Theme</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <field id="active_theme" translate="label" type="select" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Active Admin Theme</label>
+                    <source_model>MageOS\ThemeAdminhtmlSwitcher\Model\Config\Source\AdminThemeList</source_model>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
     <default>
         <admin>
             <system_admin_design>
-                <enable_theme_adminhtml_m137>1</enable_theme_adminhtml_m137>
+                <active_theme>MageOS/m137-admin-theme</active_theme>
             </system_admin_design>
         </admin>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/config_file.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <admin>
             <system_admin_design>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,2 +1,3 @@
 "Enable M137 Admin Theme","Enable M137 Admin Theme"
 "Admin Design","Admin Design"
+"Magento Default","Magento Default"


### PR DESCRIPTION
Closes #7 #8

See the issue for the rationale. Additional notes below.

This PR specifically aids us at Hyvä in regard to building our own admin theme for Hyvä Commerce using the M137 theme as a base, but we felt it may be useful for others, too, so we wanted to contribute back here. If it's not something you want included in this module, we're happy to implement this for our own needs internally instead.

I'm also aware that removing and replacing the existing configuration option with a new select-based option should be considered a major breaking change. However, as the new config option also defaults to the Mage-OS M137 Admin Theme, the only users who would be impacted are those who have already installed the theme but then disabled it, which I believe is likely to be very few people at this stage. Disabling it again is not difficult, nor does it affect business logic. At worst, it may be a minor annoyance. Open for further discussion or approaches that could mitigate this further.

I noticed a couple of small issues I've resolved in this PR (see #8), if you'd prefer these are moved in a separate PR, let me know.