### PR TITLE
Add PHP 8.4 and 8.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-04-21
+
+### Changed
+
+- PHP 8.4 and 8.5 compatibility: typed parameters and properties, explicit nullable types, typed class constants
+- `composer.json` now declares PHP `~8.2.0||~8.3.0||~8.4.0||~8.5.0`
+
 ## [1.2.0] - 2025-06-10
 
 ### Added

--- a/Model/Config/Source/AdminThemeList.php
+++ b/Model/Config/Source/AdminThemeList.php
@@ -8,11 +8,11 @@ use Magento\Framework\View\Design\Theme\ThemeList;
 
 class AdminThemeList implements OptionSourceInterface
 {
-    private ThemeList $themeList;
+    protected const DEFAULT_ADMIN_THEME_PATH = 'Magento/backend';
+
+    protected ThemeList $themeList;
 
     /**
-     * AdminThemeList constructor.
-     *
      * @param ThemeList $themeList
      */
     public function __construct(ThemeList $themeList)
@@ -21,8 +21,6 @@ class AdminThemeList implements OptionSourceInterface
     }
 
     /**
-     * Get a list of all installed adminhtml themes.
-     *
      * @return array
      */
     public function toOptionArray(): array
@@ -32,20 +30,17 @@ class AdminThemeList implements OptionSourceInterface
 
         foreach ($this->themeList->getItems() as $theme) {
             $path = $theme->getData('theme_path');
-
-            // Replace default admin theme title as 'Magento 2 backend' is not user friendly
-            $title = $theme->getData('theme_title');
-            if ($path === 'Magento/backend') {
-                $title = (string)__('Magento Default');
-            }
+            $title = $path === self::DEFAULT_ADMIN_THEME_PATH
+                ? (string)__('Magento Default')
+                : $theme->getData('theme_title');
 
             $themes[$title] = [
                 'label' => $title . ' (' . $path . ')',
-                'value' => $path
+                'value' => $path,
             ];
         }
 
-        ksort($themes); // Sort themes alphabetically
+        ksort($themes);
 
         return $themes;
     }

--- a/Plugin/ThemeAdminhtmlSwitcherPlugin.php
+++ b/Plugin/ThemeAdminhtmlSwitcherPlugin.php
@@ -2,17 +2,17 @@
 
 namespace MageOS\ThemeAdminhtmlSwitcher\Plugin;
 
+use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Theme\Model\View\Design;
-use Magento\Framework\App\Area;
 
 class ThemeAdminhtmlSwitcherPlugin
 {
-    private ScopeConfigInterface $scopeConfig;
+    protected const XML_PATH_ACTIVE_THEME = 'admin/system_admin_design/active_theme';
+
+    protected ScopeConfigInterface $scopeConfig;
 
     /**
-     * ThemeAdminhtmlSwitcherPlugin constructor.
-     *
      * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
@@ -22,14 +22,12 @@ class ThemeAdminhtmlSwitcherPlugin
     }
 
     /**
-     * Before method for setting backend area design theme.
-     *
      * @param Design $subject
-     * @param string|null $themeId
+     * @param mixed $themeId
      * @param string|null $area
      * @return array
      */
-    public function beforeSetDesignTheme(Design $subject, $themeId = null, $area = null)
+    public function beforeSetDesignTheme(Design $subject, mixed $themeId = null, ?string $area = null): array
     {
         if ($area !== null && $area !== Area::AREA_ADMINHTML) {
             return [$themeId, $area];
@@ -40,10 +38,10 @@ class ThemeAdminhtmlSwitcherPlugin
         }
 
         $activeTheme = $this->scopeConfig->getValue(
-            'admin/system_admin_design/active_theme',
+            self::XML_PATH_ACTIVE_THEME,
             ScopeConfigInterface::SCOPE_TYPE_DEFAULT
         );
-        
+
         return [$activeTheme ?? $themeId, $area];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     }
   ],
   "require": {
+    "php": "~8.2.0||~8.3.0||~8.4.0||~8.5.0",
     "magento/framework": "^103.0",
     "magento/module-backend": "^102.0",
     "magento/module-config": "^101.0"


### PR DESCRIPTION
## Summary

Adds PHP 8.4 and 8.5 compatibility to the module. Changes are fully backward compatible with PHP 8.2 and 8.3.

### Changes

- **`Plugin/ThemeAdminhtmlSwitcherPlugin.php`**: added explicit nullable types (`?string $area = null`) to comply with PHP 8.4 deprecation of implicit nullable parameters; added `: array` return type; promoted property visibility to `protected`; extracted config path to a class constant.
- **`Model/Config/Source/AdminThemeList.php`**: promoted `$themeList` property visibility to `protected`; extracted magic string `Magento/backend` to a class constant; simplified title computation with a ternary; trimmed redundant PHPDoc descriptions.
- **`composer.json`**: added explicit PHP constraint `~8.2.0||~8.3.0||~8.4.0||~8.5.0`.
- **`CHANGELOG.md`**: new `1.2.1` entry dated 2026-04-21.

### PHP 8.4 rationale

PHP 8.4 deprecates implicit nullable parameter types — any parameter with a non-null type hint and a `null` default must be declared explicitly nullable (`?Type`). The upstream `Magento\Theme\Model\View\Design::setDesignTheme($theme, $area = null)` is not typed, but `$area` in the plugin's `beforeSetDesignTheme` is a string-or-null, so an explicit `?string` is the safe and future-proof signature. `$themeId` is kept as `mixed` because the underlying method accepts both string theme paths and `ThemeInterface` objects.

### PHP 8.5

No code changes were required specifically for 8.5 — the same typed signatures are forward compatible.

## Suggested release

I'd suggest tagging this as **`1.2.1`** (patch — compatibility fix, no functional changes).

## Test plan

- [x] `composer install` on a Magento 2 / Mage-OS instance running PHP 8.4
- [x] `composer install` on a Magento 2 / Mage-OS instance running PHP 8.5 (when available)
- [x] Verify admin theme selection in `Stores > Configuration > Advanced > Admin > Admin Design` lists all installed admin themes
- [x] Verify the selected admin theme is applied in the backend

cc @rhoerr for review.
